### PR TITLE
now the empty rows in the performance table will be deleted

### DIFF
--- a/src/js/prepareOutputData.js
+++ b/src/js/prepareOutputData.js
@@ -119,8 +119,7 @@
                 var test = data.tests[testIndex];
                 if (test !== undefined && hasEngineID(test)){
                     feature['results'][test.engineID] = test.result;
-
-                    var isFirstEntry = true; 
+                    var isFirstEntry = true;
                     for (var key in test.result) {
                         if (test.result.hasOwnProperty(key)) {
 
@@ -153,10 +152,59 @@
                     }
                 }
             });
-
-
+        deleteEmptyRows(feature);
     }
 
+    function deleteEmptyRows(feature){
+         var value=false;
+         var emptyRow=[];
+         var indexOfEngine=0;
+         for(var group in feature.metricTree){
+                var metricTreeGroup=feature.metricTree[group];
+             for (var name in metricTreeGroup.metrics){
+                value=false;
+                var metricGroup=metricTreeGroup.category;
+                var metricName=metricTreeGroup.metrics[name].metric;
+                for(var engine in feature.results){
+                    var engineMetricValue=feature.results[engine][metricGroup][metricName];
+                    var valueAttributes=[];
+                    for(var valueAttribute in engineMetricValue){
+                        valueAttributes.push(valueAttribute);
+                    }
+                }
+                for (var attribute in valueAttributes){
+                     var valueAttribute=valueAttributes[attribute];
+                     if (engineMetricValue[valueAttribute]){
+                         value=true;
+                         break;
+                     }else{}
+                }
+                if (value==false){
+                    indexOfEngine=0;
+                    for (var engine in feature.results){
+                         if (indexOfEngine==0){
+
+                            emptyRow.push({
+
+                                'metricGroupNumber':group,
+                                'metricNameNumber':name
+                            });
+                            indexOfEngine++;
+                         }
+                        var resultMetricGroup=feature.results[engine][metricGroup];
+                        _.omit(resultMetricGroup,resultMetricGroup[metricName].toString());
+
+                    }
+                }
+            }
+         }
+         for (var position in emptyRow){
+
+             var metricsInTree=feature.metricTree[emptyRow[position].metricGroupNumber].metrics;
+             var indexOfMetric=metricsInTree.indexOf(metricsInTree[emptyRow[position].metricNameNumber]);
+             metricsInTree.splice(indexOfMetric,1);
+         }
+    }
     function addFeatureAndTestData(construct){
         construct['features'] = [];
         construct['supportStatus'] = {};


### PR DESCRIPTION
I added a function for the performance data to delete the empty metrics so they will not be shown in the table any more.
- [x]  If we don't have at least one value for a metric across all the engines, we can skip the row in the table
