### PR TITLE
added absolute metric as unit for Number of Instances 

### DIFF
--- a/data/metrics.json
+++ b/data/metrics.json
@@ -13,7 +13,7 @@
       "number_of_process_instances":{
          "name":"Number of Process Instances",
          "description":"The number of process instances",
-         "unit": ""
+         "unit": "absolute metric"
       },
       "cpu":{
          "name":"CPU",

--- a/src/templates/performance_table.hbs
+++ b/src/templates/performance_table.hbs
@@ -70,7 +70,7 @@
                     <tr class="collapse-row collapse in row-feat-{{@../../index}}" aria-expanded="true">
                         <td  colspan="2" class="collapse-feature-cell {{../category}}">
                             <div class="collapse-cell-border">
-                                <p>{{metricName}} {{#if metricUnit}} in {{metricUnit}}{{/if}}
+                                <p>{{metricName}} {{#if metricUnit}}{{#if_eq metricUnit "absolute metric"}} as {{else}} in {{/if_eq}}{{metricUnit}}{{/if}}
                                 </p>
                             </div>
                         </td>


### PR DESCRIPTION
I added "absolute metric" as unit for Number of Instances on the Performance Page. 
- [x]   Number of Process Instances should also be shown as absolute metric
