### PR TITLE
Support status and portability

### DIFF
--- a/src/conformance.html
+++ b/src/conformance.html
@@ -77,6 +77,9 @@
                                 <label class="btn filter-item-btn filter-supported-item">
                                     <input type="radio" name="portability_status" autocomplete="off" data-filter="portability_status" value="2">With <span class="entypo-cancel-squared"></span>
                                 </label>
+                                <label class="btn filter-item-btn filter-supported-item">
+                                    <input type="radio" name="portability_status" autocomplete="off" data-filter="portability_status" value="3">Not same<span ></span>
+                                </label>
                             </div>
                         </div>
 

--- a/src/conformance.html
+++ b/src/conformance.html
@@ -78,7 +78,7 @@
                                     <input type="radio" name="portability_status" autocomplete="off" data-filter="portability_status" value="2">With <span class="entypo-cancel-squared"></span>
                                 </label>
                                 <label class="btn filter-item-btn filter-supported-item">
-                                    <input type="radio" name="portability_status" autocomplete="off" data-filter="portability_status" value="3">Not same<span ></span>
+                                    <input type="radio" name="portability_status" autocomplete="off" data-filter="portability_status" value="3">Not Same<span ></span>
                                 </label>
                             </div>
                         </div>

--- a/src/expressiveness.html
+++ b/src/expressiveness.html
@@ -77,6 +77,9 @@
                                 <label class="btn filter-item-btn filter-supported-item">
                                     <input type="radio" name="portability_status" autocomplete="off" data-filter="portability_status" value="2">With Deviations from Standard
                                 </label>
+                                <label class="btn filter-item-btn filter-supported-item">
+                                    <input type="radio" name="portability_status" autocomplete="off" data-filter="portability_status" value="3">Not Same
+                                </label>
                             </div>
                         </div>
 

--- a/src/js/prepareOutputData.js
+++ b/src/js/prepareOutputData.js
@@ -46,13 +46,12 @@
                 construct.isFirstEntry = true;
             }  
             htmlData.constructs.push(construct);
-            console.log(htmlData);
 
         });
 
-        if(dataFilters.portability_status !== '1' && dataFilters.portability_status !== '2'&&dataFilters.portability_status !== '3'){
-            return;
-        }
+        if(dataFilters.portability_status !== '1' && dataFilters.portability_status !== '2' &&
+        dataFilters.portability_status !== '3'){ return; }
+
         filteredData.engines.forEach(function(engine){
             if(engine === undefined){ return; }
             if(dataFilters.portability_status == '1'){
@@ -157,33 +156,33 @@
         return showConstruct;
     }
     function isMatchingPortabilityStatusFeature(construct,feature){
-            var showFeature=false;
-            var supportPrevious='notSet';
-            filteredData.engines.forEach(function(engine){
+        var showFeature=false;
+        var supportPrevious='notSet';
+        filteredData.engines.forEach(function(engine){
 
-                if(engine === undefined){return;}
+            if(engine === undefined){return;}
 
-                // If any test for this engine exists or support same
-                if(feature.results.hasOwnProperty(engine.id) ){
+            // If any test for this engine exists or support same
+            if(feature.results.hasOwnProperty(engine.id) ){
 
-                    if (supportPrevious=='notSet'){
-                        supportPrevious=feature.results[engine.id].testResult;
-                    }
-                    if (supportPrevious!==feature.results[engine.id].testResult){
-                        supportPrevious='different';
-                        return;
-                    }
-                }else{
+                if (supportPrevious=='notSet'){
+                    supportPrevious=feature.results[engine.id].testResult;
+                }
+                if (supportPrevious!==feature.results[engine.id].testResult){
+                    supportPrevious='different';
+                    return;
+                }
+            }else{
                  supportPrevious='different';
                  return;
-                }
-            });
-
-            if(supportPrevious==='different'){
-                showFeature = true;
             }
+        });
 
-            return showFeature;
+        if(supportPrevious==='different'){
+            showFeature = true;
+        }
+
+        return showFeature;
     }
 
     function addPerformanceTestData(construct){
@@ -245,7 +244,7 @@
          var emptyRow=[];
          var indexOfEngine=0;
          for(var group in feature.metricTree){
-                var metricTreeGroup=feature.metricTree[group];
+             var metricTreeGroup=feature.metricTree[group];
              for (var name in metricTreeGroup.metrics){
                 value=false;
                 var metricGroup=metricTreeGroup.category;

--- a/src/js/prepareOutputData.js
+++ b/src/js/prepareOutputData.js
@@ -76,16 +76,18 @@
                         htmlData['summaryRow'][engine.id] += 1;
                     }
                     //for each construct
-                    obj['supportStatus'][engine.id]['supportedFeature']=0;
-                    obj.features.forEach(function(feature){
-                        if (feature.results.hasOwnProperty(engine.id)){
-                            if (feature.results[engine.id]['testResult']==='+'){
-                                obj['supportStatus'][engine.id]['supportedFeature']+=1;
+                    console.log(obj['supportStatus']);
+                    if(obj['supportStatus'][engine.id]!=null){
+                        obj['supportStatus'][engine.id]['supportedFeature']=0;
+                        obj.features.forEach(function(feature){
+                            if (feature.results.hasOwnProperty(engine.id)){
+                                if (feature.results[engine.id]['testResult']==='+'){
+                                    obj['supportStatus'][engine.id]['supportedFeature']+=1;
+                                }
                             }
-                        }
-                    });
+                        });
 
-
+                    }
 
                 });
             }

--- a/src/js/prepareOutputData.js
+++ b/src/js/prepareOutputData.js
@@ -318,6 +318,10 @@
                     htmlData['summaryRow'][engineID] += 1; 
                  } 
 
+            }else if (capability === 'conformance'&& construct['supportStatus'][engineID].supportedFeature > 0){
+                             construct['supportStatus'][engineID].html = '+/-' ;
+                             construct['supportStatus'][engineID].fullSupport = false;
+
             }
 
             construct['supportStatus'][engineID]['html_class'] = getResultClass(construct['supportStatus'][engineID].fullSupport,

--- a/src/js/prepareOutputData.js
+++ b/src/js/prepareOutputData.js
@@ -76,7 +76,6 @@
                         htmlData['summaryRow'][engine.id] += 1;
                     }
                     //for each construct
-                    console.log(obj['supportStatus']);
                     if(obj['supportStatus'][engine.id]!=null){
                         obj['supportStatus'][engine.id]['supportedFeature']=0;
                         obj.features.forEach(function(feature){

--- a/src/templates/conformance_table.hbs
+++ b/src/templates/conformance_table.hbs
@@ -60,7 +60,7 @@
                             {{#each instances}}
                                  <td class="result">
                                 {{#getProperty ../../supportStatus id}}
-                                    <span class="support-{{fullSupport}}">{{html}}</span>
+                                    <span class="{{html_class}}">{{html}}</span>
                                 {{/getProperty}}
 
                                 </td>


### PR DESCRIPTION
I changed that constructs where just a few featureTests are failing have "+/-" instead of "-".
- [x] Conformance: Show partially successful constructs #18

Now there is also a button "not same" for portability to show the features where the tests for the compared engines do not have the same results. If an engine has no test for a construct it is also shown as difference.
- [x] Add button to portability status stating: "not same" #26
