### PR TITLE
Engine comparison: configuration

### DIFF
--- a/src/js/engines-compare.js
+++ b/src/js/engines-compare.js
@@ -79,6 +79,14 @@ function setCompareTable() {
     htmlData['table'] = htmlData['table'] || $('#table-compare');
     htmlData.table.empty();
     addGeneralInfo();
+    var langA = getLanguageOfEngine(dataFilters.engineA);
+    var langB = getLanguageOfEngine(dataFilters.engineB);
+    if (langA == langB) {
+        $('#error-different-languages').hide();
+    } else {
+        $('#error-different-languages').show();
+        return;
+    }
     addSeparatorRow();
     getCapabilities().forEach(function (capId) {
         if (hasTests(capId) && (htmlData.rowsDisplayed.indexOf(capId) != -1)) {
@@ -110,13 +118,7 @@ function setCompareTable() {
         }
     });
 
-    var langA = getLanguageOfEngine(dataFilters.engineA);
-    var langB = getLanguageOfEngine(dataFilters.engineB);
-    if (langA == langB) {
-        $('#error-different-languages').hide();
-    } else {
-        $('#error-different-languages').show();
-    }
+
 }
 
 function listen() {

--- a/src/js/engines-compare.js
+++ b/src/js/engines-compare.js
@@ -228,7 +228,9 @@ function addGeneralInfo() {
 }
 
 function addGeneralRow(engineAData, engineBData, name) {
-    if (!dataFilters.showDifferences || engineAData != engineBData) {
+  
+    if (!dataFilters.showDifferences ||(!(typeof engineAData[0]=="undefined" && typeof engineBData[0]=="undefined"))&& engineAData != engineBData) {
+
         htmlData.table.append($('<tr></tr>')
             .addClass('general-row')
             .append($('<td>' + engineAData + '</td>').addClass('compare-cell-left'))
@@ -236,6 +238,7 @@ function addGeneralRow(engineAData, engineBData, name) {
             .append($('<td>' + engineBData + '</td>').addClass('compare-cell-right'))
             .addClass(!dataFilters.showDifferences && (engineAData == engineBData ) ? '' : 'compare-diff-result')
         );
+
     }
 }
 

--- a/src/js/engines-compare.js
+++ b/src/js/engines-compare.js
@@ -74,6 +74,7 @@ function engineCompare() {
         listen();
     });
 }
+
 function setCompareTable() {
     htmlData['table'] = htmlData['table'] || $('#table-compare');
     htmlData.table.empty();
@@ -124,8 +125,10 @@ function listen() {
         if (id == 'toggle-general') {
             htmlData.showGeneral = !htmlData.showGeneral;
             setCompareTable();
+            listen();
             return;
         }
+
         if (id != undefined) {
             id = id.replace('select-', '');
             if (childrenDisplayed(id)) {

--- a/src/js/prepareOutputData.js
+++ b/src/js/prepareOutputData.js
@@ -119,7 +119,8 @@
                 var test = data.tests[testIndex];
                 if (test !== undefined && hasEngineID(test)){
                     feature['results'][test.engineID] = test.result;
-                    var isFirstEntry = true;
+
+                    var isFirstEntry = true; 
                     for (var key in test.result) {
                         if (test.result.hasOwnProperty(key)) {
 
@@ -152,59 +153,10 @@
                     }
                 }
             });
-        deleteEmptyRows(feature);
+
+
     }
 
-    function deleteEmptyRows(feature){
-         var value=false;
-         var emptyRow=[];
-         var indexOfEngine=0;
-         for(var group in feature.metricTree){
-                var metricTreeGroup=feature.metricTree[group];
-             for (var name in metricTreeGroup.metrics){
-                value=false;
-                var metricGroup=metricTreeGroup.category;
-                var metricName=metricTreeGroup.metrics[name].metric;
-                for(var engine in feature.results){
-                    var engineMetricValue=feature.results[engine][metricGroup][metricName];
-                    var valueAttributes=[];
-                    for(var valueAttribute in engineMetricValue){
-                        valueAttributes.push(valueAttribute);
-                    }
-                }
-                for (var attribute in valueAttributes){
-                     var valueAttribute=valueAttributes[attribute];
-                     if (engineMetricValue[valueAttribute]){
-                         value=true;
-                         break;
-                     }else{}
-                }
-                if (value==false){
-                    indexOfEngine=0;
-                    for (var engine in feature.results){
-                         if (indexOfEngine==0){
-
-                            emptyRow.push({
-
-                                'metricGroupNumber':group,
-                                'metricNameNumber':name
-                            });
-                            indexOfEngine++;
-                         }
-                        var resultMetricGroup=feature.results[engine][metricGroup];
-                        _.omit(resultMetricGroup,resultMetricGroup[metricName].toString());
-
-                    }
-                }
-            }
-         }
-         for (var position in emptyRow){
-
-             var metricsInTree=feature.metricTree[emptyRow[position].metricGroupNumber].metrics;
-             var indexOfMetric=metricsInTree.indexOf(metricsInTree[emptyRow[position].metricNameNumber]);
-             metricsInTree.splice(indexOfMetric,1);
-         }
-    }
     function addFeatureAndTestData(construct){
         construct['features'] = [];
         construct['supportStatus'] = {};

--- a/src/js/prepareOutputData.js
+++ b/src/js/prepareOutputData.js
@@ -119,8 +119,7 @@
                 var test = data.tests[testIndex];
                 if (test !== undefined && hasEngineID(test)){
                     feature['results'][test.engineID] = test.result;
-
-                    var isFirstEntry = true; 
+                    var isFirstEntry = true;
                     for (var key in test.result) {
                         if (test.result.hasOwnProperty(key)) {
 
@@ -153,10 +152,59 @@
                     }
                 }
             });
-
-
+        deleteEmptyRows(feature);
     }
 
+    function deleteEmptyRows(feature){
+         var value=false;
+         var emptyRow=[];
+         var indexOfEngine=0;
+         for(var group in feature.metricTree){
+                var metricTreeGroup=feature.metricTree[group];
+             for (var name in metricTreeGroup.metrics){
+                value=false;
+                var metricGroup=metricTreeGroup.category;
+                var metricName=metricTreeGroup.metrics[name].metric;
+                for(var engine in feature.results){
+                    var engineMetricValue=feature.results[engine][metricGroup][metricName];
+                    var valueAttributes=[];
+                    for(var valueAttribute in engineMetricValue){
+                        valueAttributes.push(valueAttribute);
+                    }
+                }
+                for (var attribute in valueAttributes){
+                     var valueAttribute=valueAttributes[attribute];
+                     if (engineMetricValue[valueAttribute]){
+                         value=true;
+                         break;
+                     }else{}
+                }
+                if (value==false){
+                    indexOfEngine=0;
+                    for (var engine in feature.results){
+                         if (indexOfEngine==0){
+
+                            emptyRow.push({
+
+                                'metricGroupNumber':group,
+                                'metricNameNumber':name
+                            });
+                            indexOfEngine++;
+                         }
+                        var resultMetricGroup=feature.results[engine][metricGroup];
+                        _.omit(resultMetricGroup,resultMetricGroup[metricName].toString());
+
+                    }
+                }
+            }
+         }
+         for (var position in emptyRow){
+
+             var metricsInTree=feature.metricTree[emptyRow[position].metricGroupNumber].metrics;
+             var indexOfMetric=metricsInTree.indexOf(metricsInTree[emptyRow[position].metricNameNumber]);
+             metricsInTree.splice(indexOfMetric,1);
+         }
+    }
     function addFeatureAndTestData(construct){
         construct['features'] = [];
         construct['supportStatus'] = {};


### PR DESCRIPTION
now if the configurations are both empty and only differences should be shown the configurations are not shown any more.
- [x] Configuration is marked as difference, despite being empty string for both engines
